### PR TITLE
Add settings for Stork input and output options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    name: Lint
+    name: Lint and Test
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,9 @@ jobs:
           poetry install --no-interaction
 
       - name: Run linters
-        run: poetry run invoke lint --diff
+        run: poetry run invoke lint
+      - name: Run tests
+        run: poetry run invoke tests
 
   deploy:
     name: Deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           poetry install --no-interaction
 
       - name: Run linters
-        run: poetry run invoke lint
+        run: poetry run invoke lint --diff
       - name: Run tests
         run: poetry run invoke tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-poetry.lock
-coverage
 .coverage
+coverage
+poetry.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 poetry.lock
+__pycache__
+coverage
+.coverage
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 poetry.lock
-__pycache__
 coverage
 .coverage
-.vscode

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Once Stork has been successfully installed and tested, this plugin can be instal
 
 If you are using Pelican 4.5+ with namespace plugins and don’t have a `PLUGINS` setting defined in your configuration, then the Search plugin should be auto-discovered with no further action required. If, on the other hand, you _do_ have a `PLUGINS` setting defined (because you also use legacy plugins or because you want to be able to selectively disable installed plugins), then you must manually add `search` to the `PLUGINS` list, as described in the [Pelican plugins documentation][].
 
+
 ## Settings
 
 This plugin’s behavior can be customized via Pelican settings. Those settings, and their default values, follow below.
@@ -123,6 +124,7 @@ There are two options for serving the necessary JavaScript, WebAssembly, and CSS
 
 The first option is easier to set up. The second option is provided for folks who prefer to self-host everything. After you have decided which option you prefer, follow the relevant section’s instructions below.
 
+
 ### Static Assets — Option 1: Use CDN
 
 #### CSS
@@ -207,6 +209,7 @@ Search: <input data-stork="sitesearch" />
 
 For more information regarding this topic, see the [Stork search interface documentation](https://stork-search.net/docs/interface).
 
+
 ## Deployment
 
 Ensure your production web server serves the WebAssembly file with the `application/wasm` MIME type. For folks using older versions of Nginx, that might look like the following:
@@ -225,6 +228,7 @@ http {
 ```
 
 For other self-hosting considerations, see the [Stork self-hosting documentation](https://stork-search.net/docs/self-hosting).
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 
 This plugin generates an index for searching content on a Pelican-powered site.
 
-
 ## Why would you want this?
 
 Static sites are, well, static… and thus usually don’t have an application server component that could be used to power site search functionality. Rather than give up control (and privacy) to third-party search engine corporations, this plugin adds elegant and self-hosted site search capability to your site. Last but not least, searches are **really** fast. 🚀
-
 
 ## Installation
 
@@ -26,7 +24,6 @@ Confirm that Stork is properly installed via:
 Once Stork has been successfully installed and tested, this plugin can be installed via:
 
     python -m pip install pelican-search
-
 
 ## Settings
 
@@ -61,6 +58,20 @@ To use the default `main` selector, in each of your theme’s relevant template 
 
 For more information, refer to [Stork’s documentation on HTML tag selection](https://stork-search.net/docs/html).
 
+### `SEARCH_ADDITIONAL_OPTIONS = ""`
+
+Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here in key value style.
+
+**Example**:
+
+```python
+SEARCH_ADDITIONAL_OPTIONS = f'''
+stemming = "German"
+url_prefix = "{SITEURL}"
+'''
+```
+
+Don't add `base_directory` and `html_selector` as they are already added by default.
 
 ## Static Assets
 
@@ -84,7 +95,11 @@ Add the Stork CSS before the closing `</head>` tag in your theme’s base templa
 If your theme supports dark mode, you may want to also add Stork’s dark CSS file:
 
 ```html
-<link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="https://files.stork-search.net/dark.css">
+<link
+    rel="stylesheet"
+    media="screen and (prefers-color-scheme: dark)"
+    href="https://files.stork-search.net/dark.css"
+/>
 ```
 
 #### JavaScript
@@ -94,7 +109,7 @@ Add the following script tags to your theme’s base template, just before your 
 ```html
 <script src="https://files.stork-search.net/releases/v1.2.1/stork.js"></script>
 <script>
-    stork.register("sitesearch", "{{ SITEURL }}/search-index.st")
+    stork.register("sitesearch", "{{ SITEURL }}/search-index.st");
 </script>
 ```
 
@@ -150,7 +165,6 @@ Search: <input data-stork="sitesearch" />
 
 For more information regarding this topic, see the [Stork search interface documentation](https://stork-search.net/docs/interface).
 
-
 ## Deployment
 
 Ensure your production web server serves the WebAssembly file with the `application/wasm` MIME type. For folks using older versions of Nginx, that might look like the following:
@@ -170,7 +184,6 @@ http {
 
 For other self-hosting considerations, see the [Stork self-hosting documentation](https://stork-search.net/docs/self-hosting).
 
-
 ## Contributing
 
 Contributions are welcome and much appreciated. Every little bit helps. You can contribute by improving the documentation, adding missing features, and fixing bugs. You can also help out by reviewing and commenting on [existing issues][].
@@ -178,4 +191,4 @@ Contributions are welcome and much appreciated. Every little bit helps. You can 
 To start contributing to this plugin, review the [Contributing to Pelican][] documentation, beginning with the **Contributing Code** section.
 
 [existing issues]: https://github.com/pelican-plugins/search/issues
-[Contributing to Pelican]: https://docs.getpelican.com/en/latest/contribute.html
+[contributing to pelican]: https://docs.getpelican.com/en/latest/contribute.html

--- a/README.md
+++ b/README.md
@@ -58,17 +58,16 @@ To use the default `main` selector, in each of your theme’s relevant template 
 
 For more information, refer to [Stork’s documentation on HTML tag selection](https://stork-search.net/docs/html).
 
-### `SEARCH_ADDITIONAL_OPTIONS = ""`
+### `SEARCH_INPUT_OPTIONS = ""`
 
 Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here in key value style.
 
 **Example**:
 
 ```python
-SEARCH_ADDITIONAL_OPTIONS = f'''
-stemming = "German"
-url_prefix = "{SITEURL}"
-'''
+SEARCH_INPUT_OPTIONS = f"""stemming = "German"
+                url_prefix = "{SITEURL}"
+"""
 ```
 
 Don't add `base_directory` and `html_selector` as they are already added by default.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Static sites are, well, static… and thus usually don’t have an application s
 
 Want to see just _how_ fast? Try it out for yourself. Following are some sites that use this plugin:
 
--   [Justin Mayer](https://justinmayer.com)
--   [Open Source Alternatives](https://opensourcealternatives.org)
+* [Justin Mayer](https://justinmayer.com)
+* [Open Source Alternatives](https://opensourcealternatives.org)
 
 
 ## Installation
@@ -84,7 +84,7 @@ For more information, refer to [Stork’s documentation on HTML tag selection](h
 
 **Example**:
 
-To set it to a different selector, you can set it like this (e.g. `primary`).
+To set it to a different selector (for example, `primary`), you can set it like this:
 
 ```python
 STORK_INPUT_OPTIONS = {
@@ -123,7 +123,6 @@ There are two options for serving the necessary JavaScript, WebAssembly, and CSS
 2. Self-host the Stork static assets
 
 The first option is easier to set up. The second option is provided for folks who prefer to self-host everything. After you have decided which option you prefer, follow the relevant section’s instructions below.
-
 
 ### Static Assets — Option 1: Use CDN
 
@@ -236,6 +235,6 @@ Contributions are welcome and much appreciated. Every little bit helps. You can 
 
 To start contributing to this plugin, review the [Contributing to Pelican][] documentation, beginning with the **Contributing Code** section.
 
-[pelican plugins documentation]: https://docs.getpelican.com/en/latest/plugins.html
+[Pelican plugins documentation]: https://docs.getpelican.com/en/latest/plugins.html
 [existing issues]: https://github.com/pelican-plugins/search/issues
-[Contributing to pelican]: https://docs.getpelican.com/en/latest/contribute.html
+[Contributing to Pelican]: https://docs.getpelican.com/en/latest/contribute.html

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 
 This plugin generates an index for searching content on a Pelican-powered site.
 
+
 ## Why would you want this?
 
 Static sites are, well, static… and thus usually don’t have an application server component that could be used to power site search functionality. Rather than give up control (and privacy) to third-party search engine corporations, this plugin adds elegant and self-hosted site search capability to your site. Last but not least, searches are **really** fast. 🚀
 
 Want to see just _how_ fast? Try it out for yourself. Following are some sites that use this plugin:
 
-* [Justin Mayer](https://justinmayer.com)
-* [Open Source Alternatives](https://opensourcealternatives.org)
+-   [Justin Mayer](https://justinmayer.com)
+-   [Open Source Alternatives](https://opensourcealternatives.org)
+
 
 ## Installation
 
@@ -34,7 +36,6 @@ Once Stork has been successfully installed and tested, this plugin can be instal
 
     python -m pip install pelican-search
 
-
 If you are using Pelican 4.5+ with namespace plugins and don’t have a `PLUGINS` setting defined in your configuration, then the Search plugin should be auto-discovered with no further action required. If, on the other hand, you _do_ have a `PLUGINS` setting defined (because you also use legacy plugins or because you want to be able to selectively disable installed plugins), then you must manually add `search` to the `PLUGINS` list, as described in the [Pelican plugins documentation][].
 
 ## Settings
@@ -44,6 +45,7 @@ This plugin’s behavior can be customized via Pelican settings. Those settings,
 ### `STORK_INPUT_OPTIONS = ""`
 
 In addition to plain-text files, Stork can recognize and index HTML and Markdown-formatted content. The default behavior of this plugin is to index generated HTML files, since Stork is good at extracting content from tags, scripts, and styles. But that mode may require a slight theme modification that isn’t necessary when indexing Markdown source (see HTML selector setting below). That said, indexing Markdown means that markup information may not be removed from the indexed content and will thus be visible in the search preview results. With that caveat aside, if you want to index Markdown source content files instead of the generated HTML output, you can set `base_directory` to your content path.
+
 Any other setting then the output path will toggle the plugin to switch to "source" mode.
 
 **Example**:
@@ -54,7 +56,7 @@ STORK_INPUT_OPTIONS = {
 }
 ```
 
-#### Stork HTML selector
+#### Stork HTML Selector
 
 By default, Stork looks for `<main>[…]</main>` tags to determine where your main content is located. If such tags do not already exist in your theme’s template files, you can either (1) add `<main>` tags or (2) change the HTML selector that Stork should look for.
 
@@ -81,7 +83,7 @@ For more information, refer to [Stork’s documentation on HTML tag selection](h
 
 **Example**:
 
-To set it to a different selector, you can set it like this (e.g. primary).
+To set it to a different selector, you can set it like this (e.g. `primary`).
 
 ```python
 STORK_INPUT_OPTIONS = {
@@ -89,7 +91,7 @@ STORK_INPUT_OPTIONS = {
 }
 ```
 
-Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here as a dict.
+Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here as a `dict`.
 
 **Example**:
 
@@ -101,7 +103,7 @@ STORK_INPUT_OPTIONS = {
 
 ### `STORK_OUTPUT_OPTIONS = ""`
 
-[Output Options](https://stork-search.net/docs/config-ref) can be configured as a dict.
+[Output Options](https://stork-search.net/docs/config-ref) can be configured as a `dict`.
 Keep in mind that keys are case sensitive. They mus be lower case.
 
 **Example**:
@@ -230,6 +232,6 @@ Contributions are welcome and much appreciated. Every little bit helps. You can 
 
 To start contributing to this plugin, review the [Contributing to Pelican][] documentation, beginning with the **Contributing Code** section.
 
-[Pelican plugins documentation]: https://docs.getpelican.com/en/latest/plugins.html
+[pelican plugins documentation]: https://docs.getpelican.com/en/latest/plugins.html
 [existing issues]: https://github.com/pelican-plugins/search/issues
-[contributing to pelican]: https://docs.getpelican.com/en/latest/contribute.html
+[Contributing to pelican]: https://docs.getpelican.com/en/latest/contribute.html

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ STORK_INPUT_OPTIONS = {
 ### `STORK_OUTPUT_OPTIONS = ""`
 
 [Output Options](https://stork-search.net/docs/config-ref) can be configured as a `dict`.
-Keep in mind that keys are case sensitive. They mus be lower case.
+Keep in mind that keys are case-sensitive and must be lower case.
 
 **Example**:
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,20 @@ If you are using Pelican 4.5+ with namespace plugins and don’t have a `PLUGINS
 
 This plugin’s behavior can be customized via Pelican settings. Those settings, and their default values, follow below.
 
-### `SEARCH_MODE = "output"`
+### `STORK_INPUT_OPTIONS = ""`
 
-In addition to plain-text files, Stork can recognize and index HTML and Markdown-formatted content. The default behavior of this plugin is to index generated HTML files, since Stork is good at extracting content from tags, scripts, and styles. But that mode may require a slight theme modification that isn’t necessary when indexing Markdown source (see `SEARCH_HTML_SELECTOR` setting below). That said, indexing Markdown means that markup information may not be removed from the indexed content and will thus be visible in the search preview results. With that caveat aside, if you want to index Markdown source content files instead of the generated HTML output, you can use: `SEARCH_MODE = "source"`
+In addition to plain-text files, Stork can recognize and index HTML and Markdown-formatted content. The default behavior of this plugin is to index generated HTML files, since Stork is good at extracting content from tags, scripts, and styles. But that mode may require a slight theme modification that isn’t necessary when indexing Markdown source (see HTML selector setting below). That said, indexing Markdown means that markup information may not be removed from the indexed content and will thus be visible in the search preview results. With that caveat aside, if you want to index Markdown source content files instead of the generated HTML output, you can set `base_directory` to your content path.
+Any other setting then the output path will toggle the plugin to switch to "source" mode.
 
-### `SEARCH_HTML_SELECTOR = "main"`
+**Example**:
+
+```python
+STORK_INPUT_OPTIONS = {
+    base_directory = PATH
+}
+```
+
+#### Stork HTML selector
 
 By default, Stork looks for `<main>[…]</main>` tags to determine where your main content is located. If such tags do not already exist in your theme’s template files, you can either (1) add `<main>` tags or (2) change the HTML selector that Stork should look for.
 
@@ -70,19 +79,38 @@ To use the default `main` selector, in each of your theme’s relevant template 
 
 For more information, refer to [Stork’s documentation on HTML tag selection](https://stork-search.net/docs/html).
 
-### `SEARCH_INPUT_OPTIONS = ""`
+**Example**:
 
-Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here in key value style.
+To set it to a different selector, you can set it like this (e.g. primary).
+
+```python
+STORK_INPUT_OPTIONS = {
+    html_selector = "primary"
+}
+```
+
+Additional [Input Options](https://stork-search.net/docs/config-ref) can be added here as a dict.
 
 **Example**:
 
 ```python
-SEARCH_INPUT_OPTIONS = f"""stemming = "German"
-                url_prefix = "{SITEURL}"
-"""
+STORK_INPUT_OPTIONS = {
+    url_prefix = SITEURL
+}
 ```
 
-Don't add `base_directory` and `html_selector` as they are already added by default.
+### `STORK_OUTPUT_OPTIONS = ""`
+
+[Output Options](https://stork-search.net/docs/config-ref) can be configured as a dict.
+Keep in mind that keys are case sensitive. They mus be lower case.
+
+**Example**:
+
+```python
+STORK_OUTPUT_OPTIONS = {
+    debug = true
+}
+```
 
 ## Static Assets
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: minor
+
+* Add the ability to directly configure the underlying Stork search engine via new `STORK_INPUT_OPTIONS` and `STORK_OUTPUT_OPTIONS` settings.
+* Address [#31](https://github.com/pelican-plugins/search/issues/31) by reverting [#23](https://github.com/pelican-plugins/search/issues/23) in favor of [#15](https://github.com/pelican-plugins/search/issues/15).

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -7,7 +7,6 @@ A Pelican plugin to generate an index for static site searches.
 Copyright (c) Justin Mayer
 """
 
-from json import dumps
 import logging
 from pathlib import Path
 from shutil import which
@@ -115,11 +114,13 @@ class SearchSettingsGenerator:
             page_to_index = (
                 page.save_as if self._index_output() else page.relative_source_path
             )
+            # Escape double-quotation marks in the title
+            title = striptags(page.title).replace('"', '\\"')
             input_files.append(
                 {
                     "path": page_to_index,
                     "url": f"/{page.url}",
-                    "title": dumps(striptags(page.title)),
+                    "title": f"{title}",
                 }
             )
 

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -7,14 +7,13 @@ A Pelican plugin to generate an index for static site searches.
 Copyright (c) Justin Mayer
 """
 
-import logging
-import subprocess
 from json import dumps
+import logging
 from pathlib import Path
 from shutil import which
+import subprocess
 from typing import Dict, List
 
-import rtoml
 from jinja2.filters import do_striptags as striptags
 import rtoml
 
@@ -88,7 +87,6 @@ class SearchSettingsGenerator:
         return output.stdout
 
     def generate_stork_settings(self, search_settings_path: Path):
-
         self.input_options["files"] = self.get_input_files()
 
         search_settings = {"input": self.input_options}

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -7,15 +7,16 @@ A Pelican plugin to generate an index for static site searches.
 Copyright (c) Justin Mayer
 """
 
-from codecs import open
-from inspect import cleandoc
-from json import dumps
 import logging
-import os.path
-from shutil import which
 import subprocess
+from json import dumps
+from pathlib import Path
+from shutil import which
+from typing import Dict, List
 
+import rtoml
 from jinja2.filters import do_striptags as striptags
+import rtoml
 
 from pelican import signals
 
@@ -28,11 +29,43 @@ class SearchSettingsGenerator:
         self.context = context
         self.content = settings.get("PATH")
         self.tpages = settings.get("TEMPLATE_PAGES")
-        self.search_mode = settings.get("SEARCH_MODE", "output")
-        self.html_selector = settings.get("SEARCH_HTML_SELECTOR", "main")
-        self.input_options = settings.get("SEARCH_INPUT_OPTIONS", "")
+        self.input_options = settings.get("STORK_INPUT_OPTIONS", {})
+        self.output_options = settings.get("STORK_OUTPUT_OPTIONS")
+        # Set default values
+        self.input_options.setdefault("html_selector", "main")
+        self.input_options.setdefault("base_directory", self.output_path)
 
-    def build_search_index(self, search_settings_path):
+        # handle deprecated config variables
+        if settings.get("SEARCH_HTML_SELECTOR") and not settings.get(
+            "STORK_INPUT_OPTIONS"
+        ):
+            logger.warning(
+                "SEARCH_HTML_SELECTOR is deprecated, "
+                "and will be removed in a future version. "
+                "use STORK_INPUT_OPTIONS instead."
+            )
+            self.input_options["html_selector"] = settings.get("SEARCH_HTML_SELECTOR")
+        if settings.get("SEARCH_MODE") and not settings.get("STORK_INPUT_OPTIONS"):
+            logger.warning(
+                f"SEARCH_MODE = {settings.get('SEARCH_MODE')} is deprecated, "
+                "and will be removed in a future version. "
+                "use STORK_INPUT_OPTIONS instead."
+            )
+            self.input_options["base_directory"] = self.output_path
+            if settings.get("SEARCH_MODE") == "source":
+                self.input_options["base_directory"] = self.content
+
+    def generate_output(self, writer):
+        search_settings_path = Path(self.output_path) / "search.toml"
+
+        self.generate_stork_settings(search_settings_path)
+
+        # Build the search index
+        build_log = self.build_search_index(search_settings_path)
+        build_log = "".join(["Search plugin reported ", build_log])
+        logger.error(build_log) if "error" in build_log else logger.debug(build_log)
+
+    def build_search_index(self, search_settings_path: Path):
         if not which("stork"):
             raise Exception("Stork must be installed and available on $PATH.")
         try:
@@ -41,7 +74,7 @@ class SearchSettingsGenerator:
                     "stork",
                     "build",
                     "--input",
-                    search_settings_path,
+                    str(search_settings_path),
                     "--output",
                     f"{self.output_path}/search-index.st",
                 ],
@@ -54,67 +87,52 @@ class SearchSettingsGenerator:
 
         return output.stdout
 
-    def generate_output(self, writer):
-        search_settings_path = os.path.join(self.output_path, "search.toml")
+    def generate_stork_settings(self, search_settings_path: Path):
 
+        self.input_options["files"] = self.get_input_files()
+
+        search_settings = {"input": self.input_options}
+
+        if self.output_options:
+            search_settings["output"] = self.output_options
+
+        # Write the search settings file to disk
+        with search_settings_path.open("w") as fd:
+            rtoml.dump(obj=search_settings, file=fd)
+
+    def _index_output(self) -> bool:
+        return self.input_options["base_directory"] == self.output_path
+
+    def get_input_files(
+        self,
+    ) -> List[Dict]:
         pages = self.context["pages"] + self.context["articles"]
 
         for article in self.context["articles"]:
             pages += article.translations
 
-        input_files = ""
-
+        input_files = []
         # Generate list of articles and pages to index
         for page in pages:
-            if self.search_mode == "output":
-                page_to_index = page.save_as
-            if self.search_mode == "source":
-                page_to_index = page.relative_source_path
-            input_file = f"""
-                [[input.files]]
-                path = "{page_to_index}"
-                url = "/{page.url}"
-                title = {dumps(striptags(page.title))}
-            """
-            input_files = "".join([input_files, input_file])
+            page_to_index = (
+                page.save_as if self._index_output() else page.relative_source_path
+            )
+            input_files.append(
+                {
+                    "path": page_to_index,
+                    "url": f"/{page.url}",
+                    "title": dumps(striptags(page.title)),
+                }
+            )
 
         # Generate list of *template* pages to index (if any)
         for tpage in self.tpages:
-            if self.search_mode == "output":
-                tpage_to_index = self.tpages[tpage]
-            if self.search_mode == "source":
-                tpage_to_index = tpage
-            input_file = f"""
-                [[input.files]]
-                path = "{tpage_to_index}"
-                url = "{self.tpages[tpage]}"
-                title = ""
-            """
-            input_files = "".join([input_files, input_file])
+            tpage_to_index = self.tpages[tpage] if self._index_output() else tpage
+            input_files.append(
+                {"path": tpage_to_index, "url": self.tpages[tpage], "title": ""}
+            )
 
-        # Assemble the search settings file
-        if self.search_mode == "output":
-            base_dir = self.output_path
-        if self.search_mode == "source":
-            base_dir = self.content
-        search_settings = cleandoc(
-            f"""
-                [input]
-                base_directory = "{base_dir}"
-                html_selector = "{self.html_selector}"
-                {self.input_options}
-                {input_files}
-            """
-        )
-
-        # Write the search settings file to disk
-        with open(search_settings_path, "w", encoding="utf-8") as fd:
-            fd.write(search_settings)
-
-        # Build the search index
-        build_log = self.build_search_index(search_settings_path)
-        build_log = "".join(["Search plugin reported ", build_log])
-        logger.error(build_log) if "error" in build_log else logger.debug(build_log)
+        return input_files
 
 
 def get_generators(generators):

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -30,6 +30,7 @@ class SearchSettingsGenerator:
         self.tpages = settings.get("TEMPLATE_PAGES")
         self.search_mode = settings.get("SEARCH_MODE", "output")
         self.html_selector = settings.get("SEARCH_HTML_SELECTOR", "main")
+        self.input_options = settings.get("SEARCH_INPUT_OPTIONS", "")
 
     def build_search_index(self, search_settings_path):
         if not which("stork"):
@@ -101,6 +102,7 @@ class SearchSettingsGenerator:
                 [input]
                 base_directory = "{base_dir}"
                 html_selector = "{self.html_selector}"
+                {self.input_options}
                 {input_files}
             """
         )

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -34,21 +34,21 @@ class SearchSettingsGenerator:
         self.input_options.setdefault("html_selector", "main")
         self.input_options.setdefault("base_directory", self.output_path)
 
-        # handle deprecated config variables
+        # Handle deprecated settings
         if settings.get("SEARCH_HTML_SELECTOR") and not settings.get(
             "STORK_INPUT_OPTIONS"
         ):
             logger.warning(
-                "SEARCH_HTML_SELECTOR is deprecated, "
+                "The SEARCH_HTML_SELECTOR setting is deprecated "
                 "and will be removed in a future version. "
-                "use STORK_INPUT_OPTIONS instead."
+                "Use the STORK_INPUT_OPTIONS setting instead."
             )
             self.input_options["html_selector"] = settings.get("SEARCH_HTML_SELECTOR")
         if settings.get("SEARCH_MODE") and not settings.get("STORK_INPUT_OPTIONS"):
             logger.warning(
-                f"SEARCH_MODE = {settings.get('SEARCH_MODE')} is deprecated, "
+                f"SEARCH_MODE = {settings.get('SEARCH_MODE')} is deprecated "
                 "and will be removed in a future version. "
-                "use STORK_INPUT_OPTIONS instead."
+                "Use the STORK_INPUT_OPTIONS setting instead."
             )
             self.input_options["base_directory"] = self.output_path
             if settings.get("SEARCH_MODE") == "source":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,9 @@ classifiers = [
 python = ">=3.7,<4.0"
 pelican = ">=4.5"
 markdown = {version = ">=3.2", optional = true}
+rtoml = "^0.9.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^23"
 flake8 = "^5.0"
 flake8-black = "^0.3"
@@ -41,6 +42,8 @@ invoke = "^2.0"
 isort = "^5.4"
 livereload = "^2.6"
 markdown = "^3.2"
+pytest = "^7.2.2"
+pytest-mock = "^3.10.0"
 
 [tool.poetry.extras]
 markdown = ["markdown"]

--- a/tasks.py
+++ b/tasks.py
@@ -23,6 +23,18 @@ PTY = True if os.name != "nt" else False
 
 
 @task
+def tests(c):
+    """Run the test suite"""
+    c.run(f"{VENV}/bin/pytest", pty=True)
+
+
+@task
+def test(c):
+    """Just an alias for tests task"""
+    tests(c)
+
+
+@task
 def black(c, check=False, diff=False):
     """Run Black auto-formatter, optionally with `--check` or `--diff`."""
     check_flag, diff_flag = "", ""

--- a/tests/test_search_settings_generator.py
+++ b/tests/test_search_settings_generator.py
@@ -1,0 +1,365 @@
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from pelican.plugins.search.search import SearchSettingsGenerator
+
+
+class TestSearchSettingsGenerator:
+    def test_search_html_selector_deprecation(self, caplog):
+        test_settings = {"SEARCH_HTML_SELECTOR": "foo"}
+        generator = SearchSettingsGenerator(
+            context={},
+            settings=test_settings,
+            path=None,
+            theme=None,
+            output_path="output",
+        )
+        assert generator.input_options.get("html_selector") == "foo"
+        assert "SEARCH_HTML_SELECTOR is deprecated" in caplog.text
+
+    @pytest.mark.parametrize(
+        "deprecated_option", ["SEARCH_HTML_SELECTOR", "SEARCH_MODE"]
+    )
+    def test_ignore_deprecated_options_if_new_var_available(
+        self, caplog, deprecated_option
+    ):
+        test_settings = {
+            deprecated_option: "foo",
+            "STORK_INPUT_OPTIONS": {"foo": "bar"},
+        }
+        SearchSettingsGenerator(
+            context={},
+            settings=test_settings,
+            path=None,
+            theme=None,
+            output_path="output",
+        )
+        assert f"{deprecated_option} is deprecated" not in caplog.text
+
+    @pytest.mark.parametrize(
+        "search_mode, base_directory", [("source", "content"), ("output", "output")]
+    )
+    def test_search_mode_deprecation(self, caplog, search_mode, base_directory):
+        test_settings = {"SEARCH_MODE": search_mode, "PATH": "content"}
+        generator = SearchSettingsGenerator(
+            context={},
+            settings=test_settings,
+            path=None,
+            theme=None,
+            output_path="output",
+        )
+        assert generator.input_options.get("base_directory") == base_directory
+        assert f"SEARCH_MODE = {search_mode} is deprecated" in caplog.text
+
+    class TestGenerateOutput:
+        def test_output_path(self, mocker: MockerFixture):
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            generate_settings_mock = mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.generate_stork_settings"
+            )
+            build_index_mock = mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.build_search_index",
+                return_value="",
+            )
+            generator.generate_output(writer=None)
+            expected_search_path = Path("output") / "search.toml"
+            generate_settings_mock.assert_called_once_with(expected_search_path)
+            build_index_mock.assert_called_once_with(expected_search_path)
+
+        def test_positive_logs(self, caplog, mocker: MockerFixture):
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.generate_stork_settings"
+            )
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.build_search_index",
+                return_value="foo bar",
+            )
+            with caplog.at_level(logging.DEBUG):
+                generator.generate_output(writer=None)
+                assert "Search plugin reported foo bar" in caplog.text
+                for record in caplog.records:
+                    assert record.levelname != "ERROR"
+
+        def test_error_logs(self, caplog, mocker: MockerFixture):
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.generate_stork_settings"
+            )
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.build_search_index",
+                return_value="error bar",
+            )
+            with caplog.at_level(logging.DEBUG):
+                generator.generate_output(writer=None)
+                assert "Search plugin reported error bar" in caplog.text
+                for record in caplog.records:
+                    assert record.levelname == "ERROR"
+
+    class TestBuildSearchIndex:
+        @pytest.mark.skip("Skipped because mocking is not working")
+        def test_raise_exception_if_stork_not_there(self, mocker: MockerFixture):
+            # FIXME: This does not work. And I don;t have any other idea now.
+            mocker.patch(
+                "pelican.plugins.search.which",
+                return_value=None,
+            )
+
+            with pytest.raises(
+                Exception, match="Stork must be installed and available on \\$PATH."
+            ):
+                generator = SearchSettingsGenerator(
+                    context={},
+                    settings={},
+                    path=None,
+                    theme=None,
+                    output_path="output",
+                )
+                generator.build_search_index(Path("output"))
+
+    class TestGenerateStorkSettings:
+        def test_output_options_set(self, mocker: MockerFixture):
+
+            rtoml_patch = mocker.patch("pelican.plugins.search.rtoml.dump")
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.get_input_files",
+                return_value=[],
+            )
+            mocker.patch(
+                "pathlib.Path.open",
+            )
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={"STORK_OUTPUT_OPTIONS": {"debug": True}},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            generator.generate_stork_settings(Path("foo"))
+            assert rtoml_patch.call_args.kwargs.get("obj").get("output") == {
+                "debug": True
+            }
+
+        def test_output_options_not_set(self, mocker: MockerFixture):
+
+            rtoml_patch = mocker.patch("pelican.plugins.search.rtoml.dump")
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.get_input_files",
+                return_value=[],
+            )
+            mocker.patch(
+                "pathlib.Path.open",
+            )
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            generator.generate_stork_settings(Path("foo"))
+            assert rtoml_patch.call_args.kwargs.get("obj").get("output") is None
+
+        def test_files_added_to_input_options(self, mocker: MockerFixture):
+            test_input_files = [
+                {
+                    "path": "content/foo.md",
+                    "url": "https://blog.example.com/foo",
+                    "title": "Foo",
+                }
+            ]
+            mocker.patch(
+                "pathlib.Path.open",
+            )
+            rtoml_patch = mocker.patch("pelican.plugins.search.rtoml.dump")
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator.get_input_files",
+                return_value=test_input_files,
+            )
+            generator = SearchSettingsGenerator(
+                context={},
+                settings={},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.input_options.get("files") is None
+            generator.generate_stork_settings(Path("foo"))
+            assert (
+                rtoml_patch.call_args.kwargs.get("obj").get("input").get("files")
+                == test_input_files
+            )
+
+    class TestGetInputFiles:
+        class PageArticleMock:
+            def __init__(self, title, translations=[]):
+                self._title = title
+                self._translations = translations
+
+            @property
+            def save_as(self):
+                return "save_as"
+
+            @property
+            def relative_source_path(self):
+                return "relative"
+
+            @property
+            def url(self):
+                return "url"
+
+            @property
+            def title(self):
+                return self._title
+
+            @property
+            def translations(self):
+                return self._translations
+
+        def test_path_is_save_as_on_index_output(self):
+            generator = SearchSettingsGenerator(
+                context={"pages": [self.PageArticleMock("title")], "articles": []},
+                settings={"TEMPLATE_PAGES": []},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": '"title"',
+                }
+            ]
+
+        def test_path_is_realtive_on_index_source(self):
+            generator = SearchSettingsGenerator(
+                context={"pages": [self.PageArticleMock("title")], "articles": []},
+                settings={
+                    "TEMPLATE_PAGES": [],
+                    "STORK_INPUT_OPTIONS": {"base_directory": "content"},
+                },
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": "relative",
+                    "url": "/url",
+                    "title": '"title"',
+                }
+            ]
+
+        def test_articles_and_pages_are_collected(self):
+            generator = SearchSettingsGenerator(
+                context={
+                    "pages": [self.PageArticleMock("page")],
+                    "articles": [self.PageArticleMock("article")],
+                },
+                settings={
+                    "TEMPLATE_PAGES": [],
+                },
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": '"page"',
+                },
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": '"article"',
+                },
+            ]
+
+        def test_translations_for_articles_are_collected(self):
+            generator = SearchSettingsGenerator(
+                context={
+                    "pages": [],
+                    "articles": [
+                        self.PageArticleMock(
+                            "article", translations=[self.PageArticleMock("article-fr")]
+                        )
+                    ],
+                },
+                settings={
+                    "TEMPLATE_PAGES": [],
+                },
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": '"article"',
+                },
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": '"article-fr"',
+                },
+            ]
+
+        @pytest.mark.parametrize("is_output,expected", [(True, "dest"), (False, "src")])
+        def test_template_pages_collected(
+            self, mocker: MockerFixture, is_output: bool, expected: str
+        ):
+            mocker.patch(
+                "pelican.plugins.search.SearchSettingsGenerator._index_output",
+                return_value=is_output,
+            )
+            generator = SearchSettingsGenerator(
+                context={
+                    "pages": [],
+                    "articles": [],
+                },
+                settings={
+                    "TEMPLATE_PAGES": {
+                        "src/books.html": "dest/books.html",
+                        "src/resume.html": "dest/resume.html",
+                    }
+                },
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": f"{expected}/books.html",
+                    "url": "dest/books.html",
+                    "title": "",
+                },
+                {
+                    "path": f"{expected}/resume.html",
+                    "url": "dest/resume.html",
+                    "title": "",
+                },
+            ]

--- a/tests/test_search_settings_generator.py
+++ b/tests/test_search_settings_generator.py
@@ -140,7 +140,6 @@ class TestSearchSettingsGenerator:
 
     class TestGenerateStorkSettings:
         def test_output_options_set(self, mocker: MockerFixture):
-
             rtoml_patch = mocker.patch("pelican.plugins.search.rtoml.dump")
             mocker.patch(
                 "pelican.plugins.search.SearchSettingsGenerator.get_input_files",
@@ -162,7 +161,6 @@ class TestSearchSettingsGenerator:
             }
 
         def test_output_options_not_set(self, mocker: MockerFixture):
-
             rtoml_patch = mocker.patch("pelican.plugins.search.rtoml.dump")
             mocker.patch(
                 "pelican.plugins.search.SearchSettingsGenerator.get_input_files",

--- a/tests/test_search_settings_generator.py
+++ b/tests/test_search_settings_generator.py
@@ -18,7 +18,7 @@ class TestSearchSettingsGenerator:
             output_path="output",
         )
         assert generator.input_options.get("html_selector") == "foo"
-        assert "SEARCH_HTML_SELECTOR is deprecated" in caplog.text
+        assert "SEARCH_HTML_SELECTOR setting is deprecated" in caplog.text
 
     @pytest.mark.parametrize(
         "deprecated_option", ["SEARCH_HTML_SELECTOR", "SEARCH_MODE"]
@@ -247,7 +247,7 @@ class TestSearchSettingsGenerator:
                 {
                     "path": "save_as",
                     "url": "/url",
-                    "title": '"title"',
+                    "title": "title",
                 }
             ]
 
@@ -266,7 +266,7 @@ class TestSearchSettingsGenerator:
                 {
                     "path": "relative",
                     "url": "/url",
-                    "title": '"title"',
+                    "title": "title",
                 }
             ]
 
@@ -287,12 +287,12 @@ class TestSearchSettingsGenerator:
                 {
                     "path": "save_as",
                     "url": "/url",
-                    "title": '"page"',
+                    "title": "page",
                 },
                 {
                     "path": "save_as",
                     "url": "/url",
-                    "title": '"article"',
+                    "title": "article",
                 },
             ]
 
@@ -317,12 +317,12 @@ class TestSearchSettingsGenerator:
                 {
                     "path": "save_as",
                     "url": "/url",
-                    "title": '"article"',
+                    "title": "article",
                 },
                 {
                     "path": "save_as",
                     "url": "/url",
-                    "title": '"article-fr"',
+                    "title": "article-fr",
                 },
             ]
 


### PR DESCRIPTION
Stork index creation can be configured via [additional options](https://stork-search.net/docs/config-ref).
To allow all of them add SEARCH_ADDITIONAL_OPTIONS settings.
Content will be added to stork.toml in input block.

# Pull Request Checklist

Resolves: #4  <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
