### PR TITLE
fix(windows): convert back-slashes to forward-slashes for Windows

### DIFF
--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -7,13 +7,12 @@ A Pelican plugin to generate an index for static site searches.
 Copyright (c) Justin Mayer
 """
 
-import logging
-import os.path
-import subprocess
-
 from codecs import open
 from inspect import cleandoc
+import logging
+import os.path
 from shutil import which
+import subprocess
 
 from jinja2.filters import do_striptags as striptags
 
@@ -23,10 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 class SearchSettingsGenerator:
-
     def __init__(self, context, settings, path, theme, output_path, *null):
 
-        self.output_path = output_path.replace(os.sep, '/')
+        self.output_path = output_path.replace(os.sep, "/")
         self.context = context
         self.content = settings.get("PATH")
         self.tpages = settings.get("TEMPLATE_PAGES")
@@ -51,8 +49,7 @@ class SearchSettingsGenerator:
                 check=True,
             )
         except subprocess.CalledProcessError as e:
-            raise Exception(
-                "".join(["Search plugin reported ", e.stdout, e.stderr]))
+            raise Exception("".join(["Search plugin reported ", e.stdout, e.stderr]))
 
         return output.stdout
 
@@ -115,8 +112,7 @@ class SearchSettingsGenerator:
         # Build the search index
         build_log = self.build_search_index(search_settings_path)
         build_log = "".join(["Search plugin reported ", build_log])
-        logger.error(build_log) if "error" in build_log else logger.debug(
-            build_log)
+        logger.error(build_log) if "error" in build_log else logger.debug(build_log)
 
 
 def get_generators(generators):

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -7,12 +7,13 @@ A Pelican plugin to generate an index for static site searches.
 Copyright (c) Justin Mayer
 """
 
-from codecs import open
-from inspect import cleandoc
 import logging
 import os.path
-from shutil import which
 import subprocess
+
+from codecs import open
+from inspect import cleandoc
+from shutil import which
 
 from jinja2.filters import do_striptags as striptags
 
@@ -22,9 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 class SearchSettingsGenerator:
+
     def __init__(self, context, settings, path, theme, output_path, *null):
 
-        self.output_path = output_path
+        self.output_path = output_path.replace(os.sep, '/')
         self.context = context
         self.content = settings.get("PATH")
         self.tpages = settings.get("TEMPLATE_PAGES")
@@ -49,7 +51,8 @@ class SearchSettingsGenerator:
                 check=True,
             )
         except subprocess.CalledProcessError as e:
-            raise Exception("".join(["Search plugin reported ", e.stdout, e.stderr]))
+            raise Exception(
+                "".join(["Search plugin reported ", e.stdout, e.stderr]))
 
         return output.stdout
 
@@ -112,7 +115,8 @@ class SearchSettingsGenerator:
         # Build the search index
         build_log = self.build_search_index(search_settings_path)
         build_log = "".join(["Search plugin reported ", build_log])
-        logger.error(build_log) if "error" in build_log else logger.debug(build_log)
+        logger.error(build_log) if "error" in build_log else logger.debug(
+            build_log)
 
 
 def get_generators(generators):


### PR DESCRIPTION
### 1. Summary

Pelican Stork search doesn’t work correctly on my Windows if [**`OUTPUT_PATH`**](https://docs.getpelican.com/en/latest/settings.html?highlight=OUTPUT_PATH#basic-settings) setting is custom.

After fixing I can successfully use Pelican Stork search:

![404 page search demo](https://i.imgur.com/F7wLiKe.png)

### 2. MCVE files

You can see this MCVE configuration on the `KiraPelicanPluginsSitemapStork` branch of [**my demo repository for testing Pelican**](https://github.com/Kristinita/SashaPelicanDebugging/tree/KiraPelicanPluginsSitemapStork).

All files except those listed below are the result of running the command [**`pelican-quickstart`**](https://docs.getpelican.com/en/latest/quickstart.html).

1. `pelicanconf.py`

    ```python
    """MCVE."""

    # [INFO] Default settings
    AUTHOR = 'Sasha Chernykh'
    SITENAME = 'SashaPelicanDebugging'
    SITEURL = 'https://kristinita.netlify.app'

    PATH = 'content'

    TIMEZONE = 'Europe/Moscow'

    DEFAULT_LANG = 'en'

    ARTICLE_PATHS = [
        'Articles'
    ]

    MARKDOWN = {
        'output_format': 'html5',
    }


    # [INFO] Settings for this issue
    PLUGINS = [
        'search'
    ]

    SEARCH_HTML_SELECTOR = 'body'

    OUTPUT_PATH = 'output/'

    ```

1. `content/Articles/KiraArticle.md`:

    ```md
    Slug: KiraArticle
    Title: KiraArticle
    Date: 2020-09-24 18:57:33

    Kira Goddess!

    ```

1. `.circleci/config.yml`:

    ```yaml
    version: 2.1

    jobs:
      build:
        machine:
          image: ubuntu-2204:current
        steps:
        - checkout
        - run: pyenv global 3.10.5
        - run: pip install pelican markdown
        - run: pip install pelican-search
        # [INFO] Non-interactive Rust installation on Ubuntu
        # https://stackoverflow.com/a/57251636/5951529
        - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
        - run: cargo install stork-search --locked
        - run: stork --version
        - run: pelican content -s pelicanconf.py --fatal warnings --debug
        - run: ls output
        - run: cat output/search.toml

    ```

### 3. Behavior before change

If custom `OUTPUT_PATH` on Windows, Pelican Stork search generate invalid path slashes for the value of `base_directory` setting of `search.toml` file:

```toml
[input]
base_directory = "D:\SashaDemoRepositories\SashaPelicanDebugging\output"
html_selector = "body"

[[input.files]]
path = "KiraArticle.html"
url = "/KiraArticle.html"
title = "KiraArticle"
```

![Incorrect TOML](https://i.imgur.com/3ZWXYKQ.png)

If I run:

```python
pelican content -s pelicanconf.py --fatal warnings --ignore-cache --debug
```

I get an error:

```python
Exception: Search plugin reported Error: Couldn't read the configuration file: Cannot parse config as TOML. Stork recieved error: `invalid escape character in string: `S` at line 2 column 22`
```

Full output:

```python-traceback
D:\SashaDemoRepositories\SashaPelicanDebugging>pelican content -s pelicanconf.py --fatal warnings --ignore-cache --debug
[11:23:23] DEBUG    Pelican version: 4.8.0                                                                                                                                                                                                                        __init__.py:531
           DEBUG    Python version: 3.10.6                                                                                                                                                                                                                        __init__.py:532
           DEBUG    Adding current directory to system path                                                                                                                                                                                                        __init__.py:66
           DEBUG    Finding namespace plugins                                                                                                                                                                                                                        _utils.py:81
           DEBUG    Namespace plugins found:                                                                                                                                                                                                                         _utils.py:84
                    pelican.plugins.search
                    pelican.plugins.sitemap
           DEBUG    Loading plugin `search`                                                                                                                                                                                                                          _utils.py:90
           DEBUG    Registering plugin `pelican.plugins.search`                                                                                                                                                                                                    __init__.py:73
           DEBUG    Found generator: ArticlesGenerator (internal)                                                                                                                                                                                                 __init__.py:209
           DEBUG    Found generator: PagesGenerator (internal)                                                                                                                                                                                                    __init__.py:209
           DEBUG    Found generator: SearchSettingsGenerator (pelican.plugins.search.search)                                                                                                                                                                      __init__.py:209
           DEBUG    Found generator: StaticGenerator (internal)                                                                                                                                                                                                   __init__.py:209
           DEBUG    Template list: ['!simple/archives.html', '!simple/article.html', '!simple/author.html', '!simple/authors.html', '!simple/base.html', '!simple/categories.html', '!simple/category.html', '!simple/gosquared.html', '!simple/index.html',     generators.py:70
                    '!simple/page.html', '!simple/pagination.html', '!simple/period_archives.html', '!simple/tag.html', '!simple/tags.html', '!simple/translations.html', '!theme/analytics.html', '!theme/archives.html', '!theme/article.html',
                    '!theme/article_infos.html', '!theme/author.html', '!theme/authors.html', '!theme/base.html', '!theme/categories.html', '!theme/category.html', '!theme/comments.html', '!theme/disqus_script.html', '!theme/github.html',
                    '!theme/index.html', '!theme/page.html', '!theme/period_archives.html', '!theme/tag.html', '!theme/taglist.html', '!theme/tags.html', '!theme/translations.html', '!theme/twitter.html', 'analytics.html', 'archives.html', 'article.html',
                    'article_infos.html', 'author.html', 'authors.html', 'base.html', 'categories.html', 'category.html', 'comments.html', 'disqus_script.html', 'github.html', 'gosquared.html', 'index.html', 'page.html', 'pagination.html',
                    'period_archives.html', 'tag.html', 'taglist.html', 'tags.html', 'translations.html', 'twitter.html']
           DEBUG    Read file Articles/KiraArticle.md -> Article                                                                                                                                                                                                   readers.py:547
           DEBUG    Signal article_generator_preread.send(ArticlesGenerator)                                                                                                                                                                                       readers.py:560
           DEBUG    Successfully imported extension module "markdown.extensions.meta".                                                                                                                                                                                core.py:163
           DEBUG    Successfully loaded extension "markdown.extensions.meta.MetaExtension".                                                                                                                                                                           core.py:126
           DEBUG    Signal article_generator_context.send(ArticlesGenerator, <metadata>)                                                                                                                                                                           readers.py:627 [11:23:24] DEBUG    Read file images/.keep -> Static                                                                                                                                                                                                               readers.py:547
           DEBUG    Signal static_generator_preread.send(StaticGenerator)                                                                                                                                                                                          readers.py:560
           DEBUG    Signal static_generator_context.send(StaticGenerator, <metadata>)                                                                                                                                                                              readers.py:627
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/all.atom.xml                                                                                                                                                               writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/articles.atom.xml                                                                                                                                                          writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/sasha-chernykh.atom.xml                                                                                                                                                    writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/sasha-chernykh.rss.xml                                                                                                                                                     writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/all-en.atom.xml                                                                                                                                                            writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/KiraArticle.html                                                                                                                                                                 writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/index.html                                                                                                                                                                       writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/tags.html                                                                                                                                                                        writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/categories.html                                                                                                                                                                  writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/authors.html                                                                                                                                                                     writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/archives.html                                                                                                                                                                    writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/category/articles.html                                                                                                                                                           writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/author/sasha-chernykh.html                                                                                                                                                       writers.py:212
           CRITICAL Exception: Search plugin reported Error: Couldn't read the configuration file: Cannot parse config as TOML. Stork recieved error: `invalid escape character in string: `S` at line 2 column 22`                                               __init__.py:566

┌─────────────────────────────── Traceback (most recent call last) ────────────────────────────────┐
│ C:\Python310\lib\site-packages\pelican\plugins\search\search.py:38 in build_search_index         │
│                                                                                                  │
│    35 │   │   if not which("stork"):                                                             │
│    36 │   │   │   raise Exception("Stork must be installed and available on $PATH.")             │
│    37 │   │   try:                                                                               │
│ >  38 │   │   │   output = subprocess.run(                                                       │
│    39 │   │   │   │   [                                                                          │
│    40 │   │   │   │   │   "stork",                                                               │
│    41 │   │   │   │   │   "build",                                                               │
│                                                                                                  │
│ C:\Python310\lib\subprocess.py:524 in run                                                        │
│                                                                                                  │
│    521 │   │   │   raise                                                                         │
│    522 │   │   retcode = process.poll()                                                          │
│    523 │   │   if check and retcode:                                                             │
│ >  524 │   │   │   raise CalledProcessError(retcode, process.args,                               │
│    525 │   │   │   │   │   │   │   │   │    output=stdout, stderr=stderr)                        │
│    526 │   return CompletedProcess(process.args, retcode, stdout, stderr)                        │
│    527                                                                                           │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
CalledProcessError: Command '['stork', 'build', '--input', 'D:\\SashaDemoRepositories\\SashaPelicanDebugging\\output\\search.toml', '--output', 'D:\\SashaDemoRepositories\\SashaPelicanDebugging\\output/search-index.st']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

┌─────────────────────────────── Traceback (most recent call last) ────────────────────────────────┐
│ C:\Python310\lib\site-packages\pelican\__init__.py:562 in main                                   │
│                                                                                                  │
│   559 │   │   │   watcher = FileSystemWatcher(args.settings, Readers, settings)                  │
│   560 │   │   │   watcher.check()                                                                │
│   561 │   │   │   with console.status("Generating…"):                                          │
│ > 562 │   │   │   │   pelican.run()                                                              │
│   563 │   except KeyboardInterrupt:                                                              │
│   564 │   │   logger.warning('Keyboard interrupt received. Exiting.')                            │
│   565 │   except Exception as e:                                                                 │
│                                                                                                  │
│ C:\Python310\lib\site-packages\pelican\__init__.py:127 in run                                    │
│                                                                                                  │
│   124 │   │                                                                                      │
│   125 │   │   for p in generators:                                                               │
│   126 │   │   │   if hasattr(p, 'generate_output'):                                              │
│ > 127 │   │   │   │   p.generate_output(writer)                                                  │
│   128 │   │                                                                                      │
│   129 │   │   signals.finalized.send(self)                                                       │
│   130                                                                                            │
│                                                                                                  │
│ C:\Python310\lib\site-packages\pelican\plugins\search\search.py:113 in generate_output           │
│                                                                                                  │
│   110 │   │   │   fd.write(search_settings)                                                      │
│   111 │   │                                                                                      │
│   112 │   │   # Build the search index                                                           │
│ > 113 │   │   build_log = self.build_search_index(search_settings_path)                          │
│   114 │   │   build_log = "".join(["Search plugin reported ", build_log])                        │
│   115 │   │   logger.error(build_log) if "error" in build_log else logger.debug(build_log)       │
│   116                                                                                            │
│                                                                                                  │
│ C:\Python310\lib\site-packages\pelican\plugins\search\search.py:52 in build_search_index         │
│                                                                                                  │
│    49 │   │   │   │   check=True,                                                                │
│    50 │   │   │   )                                                                              │
│    51 │   │   except subprocess.CalledProcessError as e:                                         │
│ >  52 │   │   │   raise Exception("".join(["Search plugin reported ", e.stdout, e.stderr]))      │
│    53 │   │                                                                                      │
│    54 │   │   return output.stdout                                                               │
│    55                                                                                            │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
Exception: Search plugin reported Error: Couldn't read the configuration file: Cannot parse config as TOML. Stork recieved error: `invalid escape character in string: `S` at line 2 column 22`
```

### 4. Change

I applied [**`os.sep`**](https://docs.python.org/3/library/os#os.sep) to [**convert back-slashes to forward-slashes**](https://stackoverflow.com/a/50221144/5951529). I change [**the line of `search.py`**](https://github.com/pelican-plugins/search/blob/a608bdfcceea10cc1350026f4468d5ade17145a1/pelican/plugins/search/search.py#L27):

```diff
- self.output_path = output_path
+ self.output_path = output_path.replace(os.sep, '/')
```
                                                                                                                                                                                                                        
### 5. Behavior after change

`search.toml` on Windows after my changes:

```diff
- base_directory = "D:\SashaDemoRepositories\SashaPelicanDebugging\output"
+ base_directory = "D:/SashaDemoRepositories/SashaPelicanDebugging/output"
```

This is the correct path for Windows. No errors in output.

```python
D:\SashaDemoRepositories\SashaPelicanDebugging>pelican content -s pelicanconf.py --fatal warnings --ignore-cache --debug
[11:30:32] DEBUG    Pelican version: 4.8.0                                                                                                                                                                                                                        __init__.py:531
           DEBUG    Python version: 3.10.6                                                                                                                                                                                                                        __init__.py:532
           DEBUG    Adding current directory to system path                                                                                                                                                                                                        __init__.py:66
           DEBUG    Finding namespace plugins                                                                                                                                                                                                                        _utils.py:81
           DEBUG    Namespace plugins found:                                                                                                                                                                                                                         _utils.py:84
                    pelican.plugins.search
                    pelican.plugins.sitemap
           DEBUG    Loading plugin `search`                                                                                                                                                                                                                          _utils.py:90
           DEBUG    Registering plugin `pelican.plugins.search`                                                                                                                                                                                                    __init__.py:73
           DEBUG    Found generator: ArticlesGenerator (internal)                                                                                                                                                                                                 __init__.py:209
           DEBUG    Found generator: PagesGenerator (internal)                                                                                                                                                                                                    __init__.py:209
           DEBUG    Found generator: SearchSettingsGenerator (pelican.plugins.search.search)                                                                                                                                                                      __init__.py:209
           DEBUG    Found generator: StaticGenerator (internal)                                                                                                                                                                                                   __init__.py:209
           DEBUG    Template list: ['!simple/archives.html', '!simple/article.html', '!simple/author.html', '!simple/authors.html', '!simple/base.html', '!simple/categories.html', '!simple/category.html', '!simple/gosquared.html', '!simple/index.html',     generators.py:70
                    '!simple/page.html', '!simple/pagination.html', '!simple/period_archives.html', '!simple/tag.html', '!simple/tags.html', '!simple/translations.html', '!theme/analytics.html', '!theme/archives.html', '!theme/article.html',
                    '!theme/article_infos.html', '!theme/author.html', '!theme/authors.html', '!theme/base.html', '!theme/categories.html', '!theme/category.html', '!theme/comments.html', '!theme/disqus_script.html', '!theme/github.html',
                    '!theme/index.html', '!theme/page.html', '!theme/period_archives.html', '!theme/tag.html', '!theme/taglist.html', '!theme/tags.html', '!theme/translations.html', '!theme/twitter.html', 'analytics.html', 'archives.html', 'article.html',
                    'article_infos.html', 'author.html', 'authors.html', 'base.html', 'categories.html', 'category.html', 'comments.html', 'disqus_script.html', 'github.html', 'gosquared.html', 'index.html', 'page.html', 'pagination.html',
                    'period_archives.html', 'tag.html', 'taglist.html', 'tags.html', 'translations.html', 'twitter.html']
           DEBUG    Read file Articles/KiraArticle.md -> Article                                                                                                                                                                                                   readers.py:547
           DEBUG    Signal article_generator_preread.send(ArticlesGenerator)                                                                                                                                                                                       readers.py:560
           DEBUG    Successfully imported extension module "markdown.extensions.meta".                                                                                                                                                                                core.py:163
           DEBUG    Successfully loaded extension "markdown.extensions.meta.MetaExtension".                                                                                                                                                                           core.py:126
           DEBUG    Signal article_generator_context.send(ArticlesGenerator, <metadata>)                                                                                                                                                                           readers.py:627
           DEBUG    Read file images/.keep -> Static                                                                                                                                                                                                               readers.py:547
           DEBUG    Signal static_generator_preread.send(StaticGenerator)                                                                                                                                                                                          readers.py:560
           DEBUG    Signal static_generator_context.send(StaticGenerator, <metadata>)                                                                                                                                                                              readers.py:627
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/all.atom.xml                                                                                                                                                               writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/articles.atom.xml                                                                                                                                                          writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/sasha-chernykh.atom.xml                                                                                                                                                    writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/sasha-chernykh.rss.xml                                                                                                                                                     writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/feeds/all-en.atom.xml                                                                                                                                                            writers.py:163
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/KiraArticle.html                                                                                                                                                                 writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/index.html                                                                                                                                                                       writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/tags.html                                                                                                                                                                        writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/categories.html                                                                                                                                                                  writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/authors.html                                                                                                                                                                     writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/archives.html                                                                                                                                                                    writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/category/articles.html                                                                                                                                                           writers.py:212
           INFO     Writing D:/SashaDemoRepositories/SashaPelicanDebugging/output/author/sasha-chernykh.html                                                                                                                                                       writers.py:212
           DEBUG    Search plugin reported                                                                                                                                                                                                                          search.py:118
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\fonts.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\fonts.css                                                                                utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\main.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\main.css                                                                                  utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\pygment.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\pygment.css                                                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\reset.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\reset.css                                                                                utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\typogrify.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\typogrify.css                                                                        utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\css\wide.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\css\wide.css                                                                                  utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\font.css to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\font.css                                                                              utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\Yanone_Kaffeesatz_400.eot to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\Yanone_Kaffeesatz_400.eot                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\Yanone_Kaffeesatz_400.svg to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\Yanone_Kaffeesatz_400.svg                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\Yanone_Kaffeesatz_400.ttf to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\Yanone_Kaffeesatz_400.ttf                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\Yanone_Kaffeesatz_400.woff to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\Yanone_Kaffeesatz_400.woff                                          utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\fonts\Yanone_Kaffeesatz_400.woff2 to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\fonts\Yanone_Kaffeesatz_400.woff2                                        utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\aboutme.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\aboutme.png                                                          utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\bitbucket.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\bitbucket.png                                                      utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\delicious.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\delicious.png                                                      utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\facebook.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\facebook.png                                                        utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\github.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\github.png                                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\gitorious.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\gitorious.png                                                      utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\gittip.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\gittip.png                                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\google-groups.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\google-groups.png                                              utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\google-plus.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\google-plus.png                                                  utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\hackernews.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\hackernews.png                                                    utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\lastfm.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\lastfm.png                                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\linkedin.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\linkedin.png                                                        utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\reddit.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\reddit.png                                                            utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\rss.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\rss.png                                                                  utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\slideshare.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\slideshare.png                                                    utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\speakerdeck.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\speakerdeck.png                                                  utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\stackoverflow.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\stackoverflow.png                                              utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\twitter.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\twitter.png                                                          utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\vimeo.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\vimeo.png                                                              utils.py:332
           INFO     Copying C:\Python310\lib\site-packages\pelican\themes\notmyidea\static\images\icons\youtube.png to D:\SashaDemoRepositories\SashaPelicanDebugging\output\theme\images\icons\youtube.png                                                          utils.py:332
           INFO     Copying D:\SashaDemoRepositories\SashaPelicanDebugging\content\images\.keep to D:\SashaDemoRepositories\SashaPelicanDebugging\output\images\.keep                                                                                                utils.py:302
           INFO     Copying D:\SashaDemoRepositories\SashaPelicanDebugging\content\images\.keep to images/.keep                                                                                                                                                 generators.py:906 Done: Processed 1 article, 0 drafts, 0 hidden articles, 0 pages, 0 hidden pages and 0 draft pages in 0.56 seconds
```

### 6. UNIX possible consequences

My change shouldn’t affect \*nix operating systems. I check it on Circle CI.

1. Circle CI [**build**](https://app.circleci.com/pipelines/github/Kristinita/SashaPelicanDebugging/17/workflows/a633f5e9-3f3a-443f-b6e8-333b37062d11/jobs/17) with configuration from the item 2.3 of this issue, generated [**`search.toml`**](https://app.circleci.com/pipelines/github/Kristinita/SashaPelicanDebugging/17/workflows/a633f5e9-3f3a-443f-b6e8-333b37062d11/jobs/17/parallel-runs/0/steps/0-110):

    ```toml
    [input]
    base_directory = "/home/circleci/project/output"
    html_selector = "body"

    [[input.files]]
    path = "KiraArticle.html"
    url = "/KiraArticle.html"
    title = "KiraArticle"
    ```

1. I change in my `config.yml`:

    ```diff
    - - run: pip install pelican-search
    + - run: pip install git+https://github.com/Kristinita/search.git@KiraFixWindowsPath
    ```

Circle CI [**build**](https://app.circleci.com/pipelines/github/Kristinita/SashaPelicanDebugging/16/workflows/52bab31b-ee0a-4f00-b6f4-c28dd47ba91f/jobs/16), [**the same `search.toml`**](https://app.circleci.com/pipelines/github/Kristinita/SashaPelicanDebugging/16/workflows/52bab31b-ee0a-4f00-b6f4-c28dd47ba91f/jobs/16/parallel-runs/0/steps/0-110).

I didn’t see anything changed in Ubuntu build after my change.

### 7. Reproducing problem

I can’t reproduce my problem on free remote CI services. Unfortunately, installing Stork on Windows isn’t quick. To install Stork, a Windows user must install Rust and compile Stork on his own machine. I can to compile Stork on my machine, but I was getting bugs on [**Circle CI**](https://app.circleci.com/pipelines/github/Kristinita/SashaPelicanDebugging/14/workflows/3df6440e-7fd2-452a-810e-60a3fab6b019/jobs/14) and [**AppVeyor CI**](https://ci.appveyor.com/project/Kristinita/sashatravis/builds/44532228).

If you know how to compile Stork for Windows on free remote CI services, please, tell me. See also my [**issue**](https://github.com/jameslittle230/stork/issues/313) on the Stork issue tracker.

### 8. Environment

1. Operating system:

    1. Local — Microsoft Windows [Version 10.0.19041.1415]
    2. Circle CI — Ubuntu 22.04 LTS (Jammy Jellyfish)

2. Python — 3.10.5, 3.10.6
3. Pelican — 4.8.0
4. Stork — 1.5.0
5. pelican-search — 1.0.1

Thanks.