### PR TITLE
Escape double quotes in page titles in stork TOML file

### DIFF
--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -69,11 +69,13 @@ class SearchSettingsGenerator:
                 page_to_index = page.save_as
             if self.search_mode == "source":
                 page_to_index = page.relative_source_path
+            # Escape double quotes in title
+            title = striptags(page.title).replace('"', '\\"')
             input_file = f"""
                 [[input.files]]
                 path = "{page_to_index}"
                 url = "/{page.url}"
-                title = "{striptags(page.title)}"
+                title = "{title}"
             """
             input_files = "".join([input_files, input_file])
 


### PR DESCRIPTION
# Pull Request Checklist

Resolves: https://github.com/pelican-plugins/search/issues/3#issuecomment-1186287268

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

## Description

If a page title contains a double quote (`"`), the double quote is rendered into the stork toml file verbatim, creating a syntax error and causing stork to fail.

This PR escapes double quotes in titles (AFAICT this is the only place where they should appear) with `\"`, fixing the syntax errors.