### PR TITLE
safely wrap `title:` contents using json `dumps`

### DIFF
--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 class SearchSettingsGenerator:
     def __init__(self, context, settings, path, theme, output_path, *null):
-
         self.output_path = output_path
         self.context = context
         self.content = settings.get("PATH")

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -69,8 +69,6 @@ class SearchSettingsGenerator:
                 page_to_index = page.save_as
             if self.search_mode == "source":
                 page_to_index = page.relative_source_path
-            # Escape double quotes in title
-            title = striptags(page.title).replace('"', '\\"')
             input_file = f"""
                 [[input.files]]
                 path = "{page_to_index}"

--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -9,6 +9,7 @@ Copyright (c) Justin Mayer
 
 from codecs import open
 from inspect import cleandoc
+from json import dumps
 import logging
 import os.path
 from shutil import which
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 class SearchSettingsGenerator:
     def __init__(self, context, settings, path, theme, output_path, *null):
+
         self.output_path = output_path
         self.context = context
         self.content = settings.get("PATH")
@@ -74,7 +76,7 @@ class SearchSettingsGenerator:
                 [[input.files]]
                 path = "{page_to_index}"
                 url = "/{page.url}"
-                title = "{title}"
+                title = {dumps(striptags(page.title))}
             """
             input_files = "".join([input_files, input_file])
 


### PR DESCRIPTION
This should handle any arbitrary punctuation marks which may happen to be in the Title - `",',\,*,...etc`.

I don't undersand why this works, since we're not doing anything with  json. I just know that everything I've thrown at it comes out safely.

<s>I left the change from #15 intact, though json.dumps makes it  unnecessary. Using them both at the same time doesn't seem to change results. I've tested and verified that `"` don't become double escaped</s>

# Pull Request Checklist

Resolves: #20 

- [x] Conformed to **code style guidelines** by running appropriate linting tools

Note: as mentioned in closed PR #22 I can't run the linting during commit since my system hates it. For this PR I edited and tested and linted `search.py` on my local machine and then manually copied the changes via Github website editor. However I can't guarantee some mistake did not happen in the middle.

- [ ] Updated **documentation** for changed code

Doc updates believed unnecessary.