### PR TITLE
remove non printable chars from titles #31

### DIFF
--- a/pelican/plugins/search/search.py
+++ b/pelican/plugins/search/search.py
@@ -115,12 +115,15 @@ class SearchSettingsGenerator:
                 page.save_as if self._index_output() else page.relative_source_path
             )
             # Escape double-quotation marks in the title
-            title = striptags(page.title).replace('"', '\\"')
+            title = "".join(
+                c if c.isprintable() else " "
+                for c in striptags(page.title).replace('"', '\\"')
+            )
             input_files.append(
                 {
                     "path": page_to_index,
                     "url": f"/{page.url}",
-                    "title": f"{title}",
+                    "title": title,
                 }
             )
 

--- a/tests/test_search_settings_generator.py
+++ b/tests/test_search_settings_generator.py
@@ -361,3 +361,26 @@ class TestSearchSettingsGenerator:
                     "title": "",
                 },
             ]
+
+        @pytest.mark.parametrize("non_printable", ["\u00a0", "\u200B", "\uFEFF"])
+        def test_unicode_non_printable_chars_stripped(self, non_printable):
+            """Non printable chars should be all converted to a standard space"""
+            generator = SearchSettingsGenerator(
+                context={
+                    "pages": [
+                        self.PageArticleMock(f"title with nbsp{non_printable}char")
+                    ],
+                    "articles": [],
+                },
+                settings={"TEMPLATE_PAGES": []},
+                path=None,
+                theme=None,
+                output_path="output",
+            )
+            assert generator.get_input_files() == [
+                {
+                    "path": "save_as",
+                    "url": "/url",
+                    "title": "title with nbsp char",
+                }
+            ]


### PR DESCRIPTION
My initial idea is working only for the mentioned `\u00ad` char. I stripped the non-printable chars by replacing them by `" "`

Not sure if we need `json.dumps` and for what it was needed in the first place. If so, we should add a test case for that.
