### PR TITLE
Require rtoml>=0.13 for Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8.1,<4.0"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "pelican>=4.5",
-    "rtoml>=0.9.0",
+    "rtoml>=0.13.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
rtoml 0.13 is the first version with Python 3.14 support, but it also drops Python 3.8 and 3.9. `requires-python` needs to be updated so pdm can lock the version.

See conversation in #38.